### PR TITLE
Fix: VC/A8リンクが「広告配信準備中」エラーになる問題を修正

### DIFF
--- a/docs/js/data.js
+++ b/docs/js/data.js
@@ -28,10 +28,16 @@ window.JAPAN_DATA = (() => {
   };
 
   /* ============== URL生成ヘルパー ============== */
+  // ID未取得 (YOUR_xxx プレースホルダ) の時は直接リンクにフォールバック
+  const isPlaceholder = (s) => !s || s.startsWith("YOUR_");
   const vcLink = (pid, deepLink) =>
-    `https://ck.jp.ap.valuecommerce.com/servlet/referral?sid=${AFF_IDS.valuecommerce_sid}&pid=${pid}&vc_url=${encodeURIComponent(deepLink)}`;
+    (isPlaceholder(AFF_IDS.valuecommerce_sid) || isPlaceholder(pid))
+      ? deepLink
+      : `https://ck.jp.ap.valuecommerce.com/servlet/referral?sid=${AFF_IDS.valuecommerce_sid}&pid=${pid}&vc_url=${encodeURIComponent(deepLink)}`;
   const a8Link = (a8Id, deepLink) =>
-    `https://px.a8.net/svt/ejp?a8mat=${a8Id}&a8ejpredirect=${encodeURIComponent(deepLink)}`;
+    isPlaceholder(a8Id)
+      ? deepLink
+      : `https://px.a8.net/svt/ejp?a8mat=${a8Id}&a8ejpredirect=${encodeURIComponent(deepLink)}`;
 
   const link = {
     jalan:      (path)   => vcLink(AFF_IDS.vc_pid_jalan,   `https://www.jalan.net/${path}`),


### PR DESCRIPTION
## 問題

47都道府県モーダルから「予約・詳細→」をクリックすると、ValueCommerce の「**大変申し訳ございませんが、このリンク先は現在広告配信準備中です**」エラー画面が表示されていた。

## 原因

`AFF_IDS.valuecommerce_sid` と `vc_pid_*` が `"YOUR_VC_SID"` のままだったため、`vcLink()` が無効なURLを生成していた。同様に `a8_id_asoview` のプレースホルダで A8 リンクも壊れていた。

## 修正

`vcLink()` / `a8Link()` にプレースホルダ検出を追加：

```js
const isPlaceholder = (s) => !s || s.startsWith("YOUR_");
const vcLink = (pid, deepLink) =>
  (isPlaceholder(AFF_IDS.valuecommerce_sid) || isPlaceholder(pid))
    ? deepLink                                    // 直接リンク
    : `https://ck.jp.ap.valuecommerce.com/...`;   // VC経由
```

→ プレースホルダの間は **食べログ・じゃらん・ぐるなび等に直接遷移**（クリックは効く・ただし当面は無報酬）
→ VC/A8の本IDが入ったタイミングで **自動的にアフィリエイトリンクに昇格**

## 影響範囲

| ヘルパー | 修正前 | 修正後 |
|---|---|---|
| `link.jalan()` | VC エラー画面 | jalan.net 直接 |
| `link.tabelog()` | VC エラー画面 | tabelog.com 直接 |
| `link.gnavi()` | VC エラー画面 | r.gnavi.co.jp 直接 |
| `link.asoview()` | A8 エラー | asoview.com 直接 |
| `link.amazon()` | ✅ 既に動作 | ✅ 既に動作 |
| `link.rakutenIchiba()` | ✅ 既に動作 | ✅ 既に動作 |
| `link.yumeyado()` etc | ✅ 既に動作 | ✅ 既に動作 |

---
_Generated by [Claude Code](https://claude.ai/code/session_013Cxz5yHbUT1JNYze31eqwm)_